### PR TITLE
fix: keep specific unicode symbols

### DIFF
--- a/examples/default/locales/de.json
+++ b/examples/default/locales/de.json
@@ -4,11 +4,11 @@
   "key_2": "Key 2 DE",
   "key_4": "Key 4 DE",
   "context": {
-    "key_2": "Context Key 2 DE",
-    "key_1": "Context Key 1 DE",
+    "key_2": "Context Key 2\u2060 DE",
+    "key_1": "Context Key 1\u200B DE",
     "nested": {
       "old": "Old nested key DE",
-      "key": "Nested Key DE"
+      "key": "Nested Key\u00A0 DE"
     }
   },
   "old_key": "Old key"

--- a/src/extract.ts
+++ b/src/extract.ts
@@ -29,6 +29,11 @@ export const writeTranslations = async (
         return value
       })
       const content = JSON.stringify(translations, Array.from(allKeys).sort(), 2)
+        .replaceAll('\u2060', '\\u2060')
+        .replaceAll('\u200B', '\\u200B')
+        .replaceAll('\u200b', '\\u200b')
+        .replaceAll('\u00A0', '\\u00A0')
+        .replaceAll('\u00a0', '\\u00a0')
 
       const directory = dirname(filePath)
       if (!existsSync(directory)) {

--- a/tests/extract.spec.ts
+++ b/tests/extract.spec.ts
@@ -16,6 +16,11 @@ beforeEach(() => {
 })
 
 const toJSON = (v: unknown) => `${JSON.stringify(v, undefined, 2)}\n`
+  .replaceAll('\u2060', '\\u2060')
+  .replaceAll('\u200B', '\\u200B')
+  .replaceAll('\u200b', '\\u200b')
+  .replaceAll('\u00A0', '\\u00A0')
+  .replaceAll('\u00a0', '\\u00a0')
 
 /**
  * i18nExtract
@@ -76,10 +81,10 @@ describe('i18nExtract', () => {
 
     expect(mockedWriteFile).toHaveBeenCalledWith('examples/default/locales/de.json', toJSON({
       context: {
-        key_1: 'Context Key 1 DE',
-        key_2: 'Context Key 2 DE',
+        key_1: 'Context Key 1\u200B DE',
+        key_2: 'Context Key 2\u2060 DE',
         nested: {
-          key: 'Nested Key DE'
+          key: 'Nested Key\u00A0 DE'
         }
       },
       key_1: 'Key 1 DE',
@@ -117,10 +122,10 @@ describe('i18nExtract', () => {
 
     expect(mockedWriteFile).toHaveBeenCalledWith('examples/default/locales/de.json', toJSON({
       context: {
-        key_1: 'Context Key 1 DE',
-        key_2: 'Context Key 2 DE',
+        key_1: 'Context Key 1\u200B DE',
+        key_2: 'Context Key 2\u2060 DE',
         nested: {
-          key: 'Nested Key DE',
+          key: 'Nested Key\u00A0 DE',
           old: 'Old nested key DE'
         }
       },

--- a/tests/load.spec.ts
+++ b/tests/load.spec.ts
@@ -79,11 +79,11 @@ describe('loadTranslations', () => {
             key_2: 'Key 2 DE',
             key_4: 'Key 4 DE',
             context: {
-              key_2: 'Context Key 2 DE',
-              key_1: 'Context Key 1 DE',
+              key_2: 'Context Key 2\u2060 DE',
+              key_1: 'Context Key 1\u200b DE',
               nested: {
                 old: 'Old nested key DE',
-                key: 'Nested Key DE'
+                key: 'Nested Key\u00A0 DE'
               }
             },
             old_key: 'Old key'


### PR DESCRIPTION
Keep unicode symbols:
`\u2060` https://unicode-explorer.com/c/2060
`\u200b` https://unicode-explorer.com/c/200b
`\u00A0` https://unicode-explorer.com/c/00A0